### PR TITLE
fix/129-admin-families

### DIFF
--- a/src/components/PersonCard.js
+++ b/src/components/PersonCard.js
@@ -1,22 +1,21 @@
 import DeleteIcon from '@material-ui/icons/Delete';
 
 
-function PersonCard({ person, personType, kids, lessons, evaluations, añadir, descargar, aceptar, denegar, voluntariosData }) {
+function PersonCard({ person, personType, kids, lessons, evaluations, añadir, descargar, aceptar, rechazar, voluntariosData, trash = true }) {
   
   const handleDescargarOAceptar = (d) => {
     d ===true?descargar(voluntariosData.filter(v => v.id = person.volunteer)):aceptar(voluntariosData.filter(v => v.id = person.volunteer));
   };
   
-  const handleDenegar = () => {
-    denegar(person.id);
-  };
+
   return (
     <div className='card-info'>
       {personType === 'family' ?
       <div className='family-info'>
         <p>{person.name}</p>
         <p>Número de niños: {kids.filter(kid => kid.family === person.id).length}</p>
-      </div>:
+      </div> 
+      :
       <div className='family-request'>
         <img src={person.avatar} alt='placeholder' />
         <div className='family-info' style={{ borderRight: 'none', borderBottom: 'none'}}>
@@ -36,24 +35,23 @@ function PersonCard({ person, personType, kids, lessons, evaluations, añadir, d
               <p>Fecha de nacimiento: {kid.birthdate}</p>
               <p>Curso: {kid.current_education_year}</p>
               <p>Clase: {kidLesson ? kidLesson.name : 'Not enrolled in any class'}</p>
-              <p>Evaluacion: {kidEvaluation ? kidEvaluation.grade : 'No evaluation'}</p>
-              {kid.status === 'EXPIRED' && <p style={{ color: 'red' }}>EXPIRED</p>}
+              <p>Evaluacion: {kidEvaluation ? kidEvaluation.grade : 'No evaluacion'}</p>
+              {kid.status === 'CADUCADO' && <p style={{ color: 'red' }}>CADUCADO</p>}
             </div>
           );
         })}
       </div>
       }
-      {añadir === true ?
+      {añadir === true &&
         <div className='buttons-requests'>
-          <button className='button-contrast' onClick={() => handleDescargarOAceptar(true)}>Descargar</button>
+          <button className='button-contrast' onClick={() => descargar(person)}>Descargar</button>
           <div className='buttons-acceptance'>
-            <button className='button-accept' onClick={handleDescargarOAceptar}>Aceptar</button>
-            <button className='button-decline' onClick={handleDenegar}>Denegar</button>
+            <button className='button-accept' onClick={() => aceptar(person)}>Aceptar</button>
+            <button className='button-decline' onClick={() => rechazar(person)}>Rechazar</button>
           </div>
         </div>
-        : 
-          <DeleteIcon className='trash' onClick={handleDenegar} />
-        }
+      }
+      {trash && <DeleteIcon className='trash' onClick={() => rechazar(person)} />}
     </div>
   );
 }

--- a/src/components/PersonCard.js
+++ b/src/components/PersonCard.js
@@ -12,14 +12,14 @@ function PersonCard({ person, personType, kids, lessons, evaluations, añadir, d
     <div className='card-info'>
       {personType === 'family' ?
       <div className='family-info'>
-        <p>{person.name}</p>
+        <p><strong>{person.name}</strong></p>
         <p>Número de niños: {kids.filter(kid => kid.family === person.id).length}</p>
       </div> 
       :
       <div className='family-request'>
         <img src={person.avatar} alt='placeholder' />
         <div className='family-info' style={{ borderRight: 'none', borderBottom: 'none'}}>
-          <p>{person.name}</p>
+          {personType === 'family' ? <p><strong>{person.name}</strong></p> : <p>{person.name}</p>}
           <p>{person.edad || person.surname}</p>
         </div>
       </div>
@@ -35,7 +35,7 @@ function PersonCard({ person, personType, kids, lessons, evaluations, añadir, d
               <p>Fecha de nacimiento: {kid.birthdate}</p>
               <p>Curso: {kid.current_education_year}</p>
               <p>Clase: {kidLesson ? kidLesson.name : 'Not enrolled in any class'}</p>
-              <p>Evaluacion: {kidEvaluation ? kidEvaluation.grade : 'No evaluacion'}</p>
+              <p>Evaluación: {kidEvaluation ? kidEvaluation.grade : 'No evaluacion'}</p>
               {kid.status === 'CADUCADO' && <p style={{ color: 'red' }}>CADUCADO</p>}
             </div>
           );

--- a/src/components/ShowVolunteersAndEducators.js
+++ b/src/components/ShowVolunteersAndEducators.js
@@ -110,7 +110,14 @@ function ShowType({ type,pantallas,añadir,voluntariosAceptados,voluntariosData 
         <LayoutProfiles profile={'admin'} selected={type === "VOLUNTEER" ? 'Voluntarios': type === "EDUCATOR" ? 'Educadores': type === "PARTNER" ? 'Socios' : ''}>
             {pantallas && <Pantallas pantallas={pantallas} />}
             {typeList.map((t, index) => (
-                <PersonCard key={index} person={t} añadir={añadir} voluntariosData={voluntariosData} descargar={descargarDocumentacion} aceptar={aceptarSolicitud} denegar={denegarSolicitud}/>
+                <PersonCard 
+                    key={index} 
+                    person={t} 
+                    añadir={añadir} 
+                    voluntariosData={voluntariosData} 
+                    descargar={descargarDocumentacion} 
+                    aceptar={aceptarSolicitud} 
+                    denegar={denegarSolicitud}/>
             ))}
         </LayoutProfiles>
     );

--- a/src/components/useFetchData.js
+++ b/src/components/useFetchData.js
@@ -16,3 +16,76 @@ export default function useFetchData(API_ENDPOINT, status) {
 
   return data;
 }
+
+export function useFetchFamilies(API_ENDPOINT) {
+  const [families, setFamilies] = useState([]);
+
+  useEffect(() => {
+    axios
+      .get(`${API_ENDPOINT}family/`)
+      .then((response) => {
+        console.log('families:', response.data);
+        setFamilies(response.data);
+      })
+      .catch((error) => {
+        console.error('Error fetching families:', error);
+      });
+  }, [API_ENDPOINT]);
+
+  return families;
+}
+
+export function useFetchStudents(API_ENDPOINT, status) {
+  const [students, setStudents] = useState([]);
+
+  useEffect(() => {
+    axios
+    .get(`${API_ENDPOINT}student/`)
+    .then((response) => {
+      console.log('students:', response.data);
+      const acceptedStudents = response.data.filter(student => student.status === status);
+      setStudents(acceptedStudents);
+    })
+    .catch((error) => {
+      console.error('Error fetching students:', error);
+    });
+  }, [API_ENDPOINT, status]);
+
+  return students;
+}
+
+export function useFetchLessons(API_ENDPOINT) {
+  const [lessons, setLessons] = useState([]);
+
+  useEffect(() => {
+    axios
+      .get(`${API_ENDPOINT}lesson/`)
+      .then((response) => {
+        console.log('lessons:', response.data);
+        setLessons(response.data);
+      })
+      .catch((error) => {
+        console.error('Error fetching lessons:', error);
+      });
+  }, [API_ENDPOINT]);
+
+  return lessons;
+}
+
+export function useFetchStudentEvaluation(API_ENDPOINT) {
+  const [evaluations, setEvaluations] = useState([]);
+
+  useEffect(() => {
+    axios
+      .get(`${API_ENDPOINT}student-evaluation/`)
+      .then((response) => {
+        console.log('evaluations:', response.data);
+        setEvaluations(response.data);
+      })
+      .catch((error) => {
+        console.error('Error fetching evaluations:', error);
+      });
+  }, [API_ENDPOINT]);
+
+  return evaluations;
+}

--- a/src/screens/admin/AdminFamily.js
+++ b/src/screens/admin/AdminFamily.js
@@ -1,9 +1,9 @@
 import '../../styles/styles.css';
-import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import React from 'react';
 import LayoutProfiles from '../../components/LayoutProfiles';
 import Pantallas from '../../components/Pantallas';
 import PersonCard from '../../components/PersonCard';
+import { useFetchFamilies, useFetchLessons, useFetchStudentEvaluation, useFetchStudents } from '../../components/useFetchData';
 
 const API_ENDPOINT = process.env.REACT_APP_API_ENDPOINT
 
@@ -22,50 +22,11 @@ const pantallas = [
 
 function AdminFamily() {
 
-  const [families, setFamilies] = useState([]);
-  const [kids, setKids] = useState([]);
-  const [lessons, setLessons] = useState([]);
-  const [evaluations, setEvaluations] = useState([]);
+  const families = useFetchFamilies(API_ENDPOINT);
+  const kids = useFetchStudents(API_ENDPOINT, 'ACEPTADO');
+  const lessons = useFetchLessons(API_ENDPOINT);
+  const evaluations = useFetchStudentEvaluation(API_ENDPOINT);
 
-  useEffect(() => {
-    axios
-      .get(`${API_ENDPOINT}family/`)
-      .then((response) => {
-        console.log('families:', response.data);
-        setFamilies(response.data);
-      })
-      .catch((error) => {
-        console.error('Error fetching families:', error);
-      });
-    axios
-      .get(`${API_ENDPOINT}student/`)
-      .then((response) => {
-        console.log('students:', response.data);
-        const acceptedStudents = response.data.filter(student => student.status === "ACEPTADO");
-        setKids(acceptedStudents);
-      })
-      .catch((error) => {
-        console.error('Error fetching students:', error);
-      });
-    axios
-      .get(`${API_ENDPOINT}lesson/`)
-      .then((response) => {
-        console.log('lessons:', response.data);
-        setLessons(response.data);
-      })
-      .catch((error) => {
-        console.error('Error fetching lessons:', error);
-      });
-    axios
-      .get(`${API_ENDPOINT}student-evaluation/`)
-      .then((response) => {
-        console.log('evaluations:', response.data);
-        setEvaluations(response.data);
-      })
-      .catch((error) => {
-        console.error('Error fetching evaluations:', error);
-      });
-  }, []);
   
   return (
     <LayoutProfiles profile={'admin'} selected={'Familias'}>

--- a/src/screens/admin/AdminFamily.js
+++ b/src/screens/admin/AdminFamily.js
@@ -41,7 +41,8 @@ function AdminFamily() {
       .get(`${API_ENDPOINT}student/`)
       .then((response) => {
         console.log('students:', response.data);
-        setKids(response.data);
+        const acceptedStudents = response.data.filter(student => student.status === "ACEPTADO");
+        setKids(acceptedStudents);
       })
       .catch((error) => {
         console.error('Error fetching students:', error);
@@ -70,14 +71,15 @@ function AdminFamily() {
     <LayoutProfiles profile={'admin'} selected={'Familias'}>
 
       <Pantallas pantallas={pantallas}/>
-      {families.map((t, index) => (
+      {families.map((f, index) => (
           <PersonCard 
             key={index} 
-            person={t} 
+            person={f} 
             personType='family'
             kids={kids}
             lessons={lessons}
             evaluations={evaluations}
+            trash={false}
           />
       ))}
 

--- a/src/screens/admin/AdminFamilyRequests.js
+++ b/src/screens/admin/AdminFamilyRequests.js
@@ -83,6 +83,7 @@ function AdminFamilyRequests() {
           <PersonCard 
             key={index} 
             person={t} 
+            personType='family'
             añadir={true} 
             descargar={handleDescargar}
             aceptar={handleAceptar}

--- a/src/screens/admin/AdminFamilyRequests.js
+++ b/src/screens/admin/AdminFamilyRequests.js
@@ -1,10 +1,10 @@
 // AdminFamilyRequests.js
 import '../../styles/styles.css';
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 import LayoutProfiles from '../../components/LayoutProfiles';
 import PersonCard from '../../components/PersonCard';
 import Pantallas from '../../components/Pantallas';
+import { useFetchFamilies, useFetchStudents } from '../../components/useFetchData';
 
 const API_ENDPOINT = process.env.REACT_APP_API_ENDPOINT;
 
@@ -24,31 +24,10 @@ const pantallas = [
 
 function AdminFamilyRequests() {
   
-  const [families, setFamilies] = useState([]);
-  const [kids, setKids] = useState([]);
+  const families = useFetchFamilies(API_ENDPOINT);
+  const kids = useFetchStudents(API_ENDPOINT, 'PENDIENTE');
   const [persons, setPersons] = useState([]);
 
-  useEffect(() => {
-    axios
-      .get(`${API_ENDPOINT}family/`)
-      .then((response) => {
-        console.log('families:', response.data);
-        setFamilies(response.data);
-      })
-      .catch((error) => {
-        console.error('Error fetching families:', error);
-      });
-    axios
-      .get(`${API_ENDPOINT}student/`)
-      .then((response) => {
-        console.log('students:', response.data);
-        const studentsRequests = response.data.filter(student => student.status === "PENDIENTE");
-        setKids(studentsRequests);
-      })
-      .catch((error) => {
-        console.error('Error fetching students:', error);
-      });
-  }, []);
   
   useEffect(() => {
     if (families.length > 0 && kids.length > 0) {


### PR DESCRIPTION
Fixed the admin families and admin families requests with the new backend and totally responsive. 

On admin families, you can see:
- the family name and number of kids accepted on the left
- kids info on the right (pending what info does the ong manager want to see of the kids)

On admin families requests, you can see:
- the avatar of the student (not yet properly displayed because backend does not have photos)
- buttons for downloading the enrollment document of the student, acepting the student and rejecting the student (there is currently a window alert because these implementations are not made yet in the backend)