### PR TITLE
Fix: api url for deploy

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
-//TODO
+//.env.production
+REACT_APP_API_ENDPOINT=https://nexongapi.ew.r.appspot.com/api/


### PR DESCRIPTION
In this PR the url for doing the npm build needed for the deploy in app engine has been change so it uses the one correspodning to the backend api.