### PR TITLE
hotfix/homepage-transparency-table

### DIFF
--- a/src/components/useFetchData.js
+++ b/src/components/useFetchData.js
@@ -425,10 +425,8 @@ export function UseFetchDocuments(API_ENDPOINT, token) {
 
   useEffect(()=> {
     axios
-    .get(`${API_ENDPOINT}home-document/`, {headers: {
-      'Authorization': `Bearer ${token}`
-    }
-  })
+    .get(`${API_ENDPOINT}home-document/`
+  )
     .then((response) => {
       console.log('documents:', response.data);
       setDocuments(response.data);
@@ -440,6 +438,7 @@ export function UseFetchDocuments(API_ENDPOINT, token) {
 
   return documents;
 }
+
 
 
 


### PR DESCRIPTION
There was an error in the useFetchData.js where it was asking for the authorization token to get the documents for the table, when is something that should be done without being logged in.

To see that it's working you should add a document as an admin and check that it appears correctly in the Homepage Transparency screen.